### PR TITLE
Extend sqlite abi for create function

### DIFF
--- a/sqlite3_abi.nim
+++ b/sqlite3_abi.nim
@@ -5,3 +5,26 @@ import sqlite3_gen
 export sqlite3_gen
 
 proc sqlite3_bind_blob*(pstmt: ptr sqlite3_stmt, param: cint, value: pointer, n: cint, dispose: proc (v: pointer) {.cdecl.}): cint {.importc, cdecl.}
+
+proc sqlite3_create_function*(
+  db: ptr sqlite3,
+  functionName: cstring,
+  nArgs: cint,
+  eTextRep: cint,
+  pApp: pointer,
+  xFunc: proc(ctx: ptr sqlite3_context, n: cint, v: ptr ptr sqlite3_value) {.cdecl.},
+  xStep: proc(ctx: ptr sqlite3_context, n: cint, v: ptr ptr sqlite3_value) {.cdecl.},
+  xFinal: proc(ctx: ptr sqlite3_context) {.cdecl.}
+): cint {.importc, cdecl.}
+
+proc sqlite3_result_blob*(
+  ctx: ptr sqlite3_context,
+  bytes: pointer,
+  n: cint,
+  dispose: proc (v: pointer) {.cdecl.}
+) {.importc, cdecl.}
+
+# constant which corresponds to SQLITE_TRANSIENT flag. Instructs sqlite to copy
+# data pointed by sqlite3_result_blob.bytes pointer. Then sqlite is reponsible
+# for deallocating this copied memory.
+const sqliteTransient* = cast[sqlite3_destructor_type](-1)

--- a/sqlite3_abi.nim
+++ b/sqlite3_abi.nim
@@ -27,4 +27,4 @@ proc sqlite3_result_blob*(
 # constant which corresponds to SQLITE_TRANSIENT flag. Instructs sqlite to copy
 # data pointed by sqlite3_result_blob.bytes pointer. Then sqlite is reponsible
 # for deallocating this copied memory.
-const sqliteTransient* = cast[sqlite3_destructor_type](-1)
+const SQLITE_TRANSIENT* = cast[sqlite3_destructor_type](-1)


### PR DESCRIPTION
Extends sqlite abi by two procs:
`sqlite3_create_function `
`sqlite3_result_blob`

Those two functions are necessary to implement handling of user defined functions by sqlite.

Current intention is to use this capability in fluffy to implement custom distance function which will calculate xor distance between two blobs. It will enable searching of content close to any node id.